### PR TITLE
stop removing `'\a`  (internal multi-line delimiter)

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -553,9 +553,6 @@ static void stripcom(unsigned char *line)
         } /* if */
       } /* if */
     } /* if */
-    if (*line == '\a') {
-      memmove(line,line+1,strlen((char *)line+1)+1);
-    }
   } /* while */
   #if !defined SC_LIGHT
     if (icomment==2) {


### PR DESCRIPTION
This reverts a part of https://github.com/Southclaws/pawn/commit/693591bdc3491133f2aa90498c4ad8d3aadd0eb7 which caused issues as described in #226.

https://github.com/Southclaws/pawn/commit/e7ecf386f8e82ed03a3627712d2064940c61aeb4 added code A and code B.

https://github.com/Southclaws/pawn/commit/693591bdc3491133f2aa90498c4ad8d3aadd0eb7 removed code A.

This PR removes code B; essentially reverting the fix.

Might add more commits to the PR later if not merged.
  