### PR TITLE
pawndisasm: Fix 'switch' argument

### DIFF
--- a/source/compiler/pawndisasm.c
+++ b/source/compiler/pawndisasm.c
@@ -355,7 +355,7 @@ cell do_sysreq(FILE *ftxt,const cell *params,cell opcode,cell cip)
 cell do_switch(FILE *ftxt,const cell *params,cell opcode,cell cip)
 {
   print_opcode(ftxt,opcode,cip);
-  fprintf(ftxt,"%08"PRIxC"\n",*params+cip);
+  fprintf(ftxt,"%08"PRIxC"\n",*params);
   return 2;
 }
 


### PR DESCRIPTION
Fixes #179.
Test code:
```Pawn
native random(max);
main()
{
	static x;
	switch (random(1))
	{
		case 1: x = 1;
		default:x = 0;
	}
	#pragma unused x
}
```
`pawndisasm` output before this patch:
```
00000000  halt 00000000

00000008  proc 
0000000c  break 
00000010  break 
00000014  push.c 00000001
0000001c  push.c 00000004
00000024  sysreq.c 00000000	; random
0000002c  stack 00000008
00000034  switch 000000a0
0000003c  break 
00000040  const.pri 00000001
00000048  stor.pri 00000000
00000050  jump 00000080
00000058  break 
0000005c  zero 00000000
00000064  jump 00000080
0000006c  casetbl 00000001 00000058
                  00000001 0000003c
00000080  zero.pri 
00000084  retn 
```
Note the address after the `switch` instruction is incorrect, the case table (`casetbl`) is at `0000006c`, not `000000a0`.

Output after the patch:
```
00000000  halt 00000000

00000008  proc 
0000000c  break 
00000010  break 
00000014  push.c 00000001
0000001c  push.c 00000004
00000024  sysreq.c 00000000	; random
0000002c  stack 00000008
00000034  switch 0000006c
0000003c  break 
00000040  const.pri 00000001
00000048  stor.pri 00000000
00000050  jump 00000080
00000058  break 
0000005c  zero 00000000
00000064  jump 00000080
0000006c  casetbl 00000001 00000058
                  00000001 0000003c
00000080  zero.pri 
00000084  retn 
```