### PR TITLE
Memoize the last node in constvalue lists

### DIFF
--- a/source/compiler/sc.h
+++ b/source/compiler/sc.h
@@ -113,6 +113,10 @@ typedef struct s_constvalue {
                          * tag for enumeration lists */
 } constvalue;
 
+typedef struct s_constvalue_root {
+  constvalue *next,*last;
+} constvalue_root;
+
 /*  Symbol table format
  *
  *  The symbol name read from the input file is stored in "name", the

--- a/source/compiler/sc1.c
+++ b/source/compiler/sc1.c
@@ -4906,8 +4906,8 @@ static void destructsymbols(symbol *root,int level)
     popreg(sPRI);
 }
 
-static constvalue *insert_constval(constvalue *prev,constvalue *next,const char *name,cell val,
-                                   int index)
+static constvalue *insert_constval(constvalue *prev,constvalue *next,
+                                   const char *name,cell val,int index)
 {
   constvalue *cur;
 
@@ -4927,12 +4927,12 @@ static constvalue *insert_constval(constvalue *prev,constvalue *next,const char 
 
 SC_FUNC constvalue *append_constval(constvalue *table,const char *name,cell val,int index)
 {
-  constvalue *cur,*prev;
+  constvalue_root *root=(constvalue_root *)table;
+  constvalue *newvalue;
 
-  /* find the end of the constant table */
-  for (prev=table, cur=table->next; cur!=NULL; prev=cur, cur=cur->next)
-    /* nothing */;
-  return insert_constval(prev,NULL,name,val,index);
+  newvalue=insert_constval(((root->last!=NULL) ? root->last : table),NULL,name,val,index);
+  root->last=newvalue;
+  return newvalue;
 }
 
 SC_FUNC constvalue *find_constval(constvalue *table,char *name,int index)
@@ -4962,12 +4962,15 @@ static constvalue *find_constval_byval(constvalue *table,cell val)
 #if 0   /* never used */
 static int delete_constval(constvalue *table,char *name)
 {
-  constvalue *prev = table;
-  constvalue *cur = prev->next;
+  constvalue *prev=table;
+  constvalue *cur=prev->next;
+  constvalue_root *root=(constvalue_root *)table;
 
   while (cur!=NULL) {
     if (strcmp(name,cur->name)==0) {
       prev->next=cur->next;
+      if (root->last==cur)
+        root->last=prev;
       free(cur);
       return TRUE;
     } /* if */


### PR DESCRIPTION
The first node in constvalue lists is always treated differently than the others, only its `next` field is used, so it should be safe to reporpose a part of unused space to memoize the address of the last node in the list. This should speed up the addition of new nodes to the end of the list.